### PR TITLE
Install wagtail only if needed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
     author_email='tim@takeflight.com.au',
     url='https://bitbucket.org/takeflight/wagtailsettings',
 
-    install_requires=['wagtail>=0.6'],
+    install_requires=[],
+    extras_require={
+        'full': ['wagtail>=0.6'],
+    },
     zip_safe=False,
     license='BSD License',
 


### PR DESCRIPTION
In my case, I'm using not yet released to pypi wagtail, from master branch, and this setup script tries to install old wagtail and old django.
